### PR TITLE
swap_order: relax cancel policy from AllOf to AtLeast(2, owners)

### DIFF
--- a/journal/2026/lib/swap_order.sh
+++ b/journal/2026/lib/swap_order.sh
@@ -15,15 +15,18 @@ swap_order() {
   "fields": [
     { "constructor": 0, "fields": [{ "bytes": "$SUNDAE_USDM_POOL" }] },
     {
-      "constructor": 1,
-      "fields": [{
-        "list": [
-          { "constructor": 0, "fields": [ { "bytes": "$(echo "$metadata" | jq -cr ".treasuries.core_development.owner")" } ] },
-          { "constructor": 0, "fields": [ { "bytes": "$(echo "$metadata" | jq -cr ".treasuries.ops_and_use_cases.owner")" } ] },
-          { "constructor": 0, "fields": [ { "bytes": "$(echo "$metadata" | jq -cr ".treasuries.network_compliance.owner")" } ] },
-          { "constructor": 0, "fields": [ { "bytes": "$(echo "$metadata" | jq -cr ".treasuries.middleware.owner")" } ] }
-        ]
-      }]
+      "constructor": 3,
+      "fields": [
+        { "int": 2 },
+        {
+          "list": [
+            { "constructor": 0, "fields": [ { "bytes": "$(echo "$metadata" | jq -cr ".treasuries.core_development.owner")" } ] },
+            { "constructor": 0, "fields": [ { "bytes": "$(echo "$metadata" | jq -cr ".treasuries.ops_and_use_cases.owner")" } ] },
+            { "constructor": 0, "fields": [ { "bytes": "$(echo "$metadata" | jq -cr ".treasuries.network_compliance.owner")" } ] },
+            { "constructor": 0, "fields": [ { "bytes": "$(echo "$metadata" | jq -cr ".treasuries.middleware.owner")" } ] }
+          ]
+        }
+      ]
     },
     { "int": $SUNDAE_PROTOCOL_FEE_LOVELACE },
     {


### PR DESCRIPTION
As discussed in the Discord channel.

## Summary

Flip the SundaeSwap V3 order owner-policy embedded into the swap order datum from `AllOf` (4-of-4 owners) to `AtLeast 2` (2-of-4 owners). One-file change in `journal/2026/lib/swap_order.sh`.

## Rationale

Any **2** of the 4 treasury scope owners can already disburse funds out of the treasury at will. Requiring **all 4** signatures merely to cancel a pending swap order — and return the locked ADA back to that same treasury — is therefore strictly more restrictive than the disburse permission and creates a denial-of-cancellation risk if any one owner is unavailable. Aligning the swap-cancel policy with the disburse threshold makes cancellation no easier than spending the returned funds, so the change does not weaken control.

## Plutus-data shape change

Per the SundaeSwap aicone multisig schema (0=Signature, 1=AllOf, 2=AnyOf, 3=AtLeast, 4=Before, 5=After):

```diff
- AllOf [Signature(core_dev), Signature(ops), Signature(network_compliance), Signature(middleware)]
+ AtLeast 2 [Signature(core_dev), Signature(ops), Signature(network_compliance), Signature(middleware)]
```

In the bash recipe's JSON:

```diff
-    "constructor": 1,
-    "fields": [{ "list": [ ...4 owner signatures... ] }]
+    "constructor": 3,
+    "fields": [
+      { "int": 2 },
+      { "list": [ ...4 owner signatures... ] }
+    ]
```

## Scope

- Only swap orders **built going forward** by this script are affected.
- Past orders already on chain are immutable and keep whatever policy they were created with.
- No other scripts change.