### PR TITLE
fix: pad contingency registry_script.hash to 28 bytes

### DIFF
--- a/journal/2026/metadata.json
+++ b/journal/2026/metadata.json
@@ -82,7 +82,7 @@
         "deployed_at": "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#04"
       },
       "registry_script": {
-        "hash": "7d275cf8c09fd91e73879993ef13cb73915196478d5e3777992f988",
+        "hash": "7d275cf8c09fd91e73879993ef13cb73915196478d5e3777992f9888",
         "deployed_at": "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#04"
       }
     }


### PR DESCRIPTION
One-character JSON fix in `journal/2026/metadata.json`.

The contingency scope's `registry_script.hash` was 27.5 bytes
(missing the trailing `8`):

```
metadata:  7d275cf8c09fd91e73879993ef13cb73915196478d5e3777992f988    (27.5 B)
on-chain:  7d275cf8c09fd91e73879993ef13cb73915196478d5e3777992f9888  (28 B)
```

Intent builders that verify metadata against chain anchors
(amaru-treasury-tx contingency-disburse-wizard) abort with
`AnchorMismatch "registry_script.hash" (Just Contingency)` on
every fresh clone, blocking contingency-flavoured operations.

Verified against the live deployment ref
`e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#04`.

Related: pragma-org/amaru-treasury#19.